### PR TITLE
Change wam.sessions to user_sessions.sessions

### DIFF
--- a/apps.py
+++ b/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 from wam import settings
-from wam.sessions import SessionData
+from user_sessions.sessions import SessionData
 
 
 class StempAbwConfig(AppConfig):


### PR DESCRIPTION
Hi,

the import of user sessions in the WAM base project was changed from wam.sessions to user_sessions.sessions. This fix-pull request changes the import to the new user_sessions.sessions import module.

Regards,
Alexis