### PR TITLE
correct model name in feature property of GeoJSON

### DIFF
--- a/models.py
+++ b/models.py
@@ -90,6 +90,19 @@ class RegMun(LayerModel):
     pop_km2 = models.FloatField(null=True)
 
 
+class RegMunPopDensity(RegMun):
+    """This is a proxy model for RegMun which got same relations to the DB
+    table but changes the model name. This is needed to load the appropriate
+    DetailView when clicking on a map feature (serialized property in the data
+    view).
+    See Also: https://github.com/rl-institut/WAM_APP_stemp_abw/issues/2
+    """
+    name = 'reg_mun_pop_density'
+
+    class Meta:
+        proxy = True
+
+
 class RegWaterProtArea(LayerModel):
     name = 'reg_water_prot_area'
     geom = geomodels.MultiPolygonField(srid=3035, null=True)

--- a/urls.py
+++ b/urls.py
@@ -23,7 +23,7 @@ for name, obj in inspect.getmembers(views.detail_views):
     if inspect.isclass(obj):
         if issubclass(obj, views.detail_views.MasterDetailView):
             if obj.model is not None:
-                detail_views[obj.model_name if hasattr(obj, 'model_name') else obj.model.name] = obj
+                detail_views[obj.model.name] = obj
 urlpatterns.extend(
     path('popup/{}/<int:pk>/'.format(name), dview.as_view(), name='{}-detail'.format(name))
     for name, dview in detail_views.items()
@@ -36,7 +36,7 @@ for name, obj in inspect.getmembers(views.serial_views):
     if inspect.isclass(obj):
         if issubclass(obj, GeoJSONLayerView):
             if obj.model is not None:
-                data_views[obj.model_name if hasattr(obj, 'model_name') else obj.model.name] = obj
+                data_views[obj.model.name] = obj
 urlpatterns.extend(
     re_path(r'^{}.data/'.format(name), sview.as_view(), name='{}.data'.format(name))
     for name, sview in data_views.items()

--- a/views/detail_views.py
+++ b/views/detail_views.py
@@ -36,8 +36,7 @@ class RegMunDetailView(MasterDetailView):
 
 
 class RegMunPopDensityDetailView(MasterDetailView):
-    model = models.RegMun
-    model_name = 'reg_mun_pop_density'
+    model = models.RegMunPopDensity
     template_name = 'stemp_abw/layer_popup_reg_mun_pop_density.html'
 
 

--- a/views/serial_views.py
+++ b/views/serial_views.py
@@ -38,13 +38,14 @@ class RegMunData(GeoJSONLayerView):
     geometry_field = 'geom'
     precision = 5
 
+
 class RegMunPopDensityData(GeoJSONLayerView):
-    model = models.RegMun
-    model_name = 'reg_mun_pop_density'
+    model = models.RegMunPopDensity
     properties = ['popup_content', 'name', 'gen', 'pop_km2']
     srid = 4326
     geometry_field = 'geom'
     precision = 5
+
 
 class RegWaterProtAreaData(GeoJSONLayerView):
     model = models.RegWaterProtArea


### PR DESCRIPTION
A [proxy model](https://docs.djangoproject.com/en/2.1/topics/db/models/#proxy-models) is used to allow referencing to the correct detail view.

This fix seems ok for now, but still facing the redundant information as the name is serialized for every feature, cf. #2 no. 2). We should consider to pass the serial data via context to allow for more meta info.