### PR TITLE
Change highcharts init to reflect API change

### DIFF
--- a/results.py
+++ b/results.py
@@ -23,7 +23,9 @@ class ResultAnalysisVisualization(object):
         #self.data = pd.Series(random(10), name='test')
 
     def visualize(self):
-        visualization = visualizations.HCTimeseries(data=self.data,
-                                                    title=self.title)
-        div_kwargs = {'style': 'display: inline-block'}
-        return visualization.render(div_kwargs=div_kwargs)
+        visualization = visualizations.HCTimeseries(
+            data=self.data,
+            title=self.title,
+            style='display: inline-block'
+        )
+        return visualization

--- a/visualizations.py
+++ b/visualizations.py
@@ -1,14 +1,15 @@
-from utils.highcharts import Highchart, RLI_THEME
+from utils.highcharts import Highchart
 
 
 class HCStemp(Highchart):
     setup = {}
 
-    def __init__(self, data=None, **kwargs):
-        super(HCStemp, self).__init__(data,
-                                      theme=RLI_THEME,
-                                      setup=self.setup,
-                                      **kwargs)
+    def __init__(self, data=None, title='New Highchart', **kwargs):
+        super(HCStemp, self).__init__(**kwargs)
+        self.set_dict_options(self.setup)
+        self.set_options('title', {'text': title})
+        if data is not None:
+            self.add_pandas_data_set(data)
 
 
 class HCTimeseries(HCStemp):


### PR DESCRIPTION
Hi @nesnoj,

- after pulling the newest WAM version I couldn't migrate the meta app. @henhuy showed me how to fix this, by reverting the migration of the meta app:
```
python manage.py migrate meta zero
```
And remigrating the meta app again:
```
python manage.py migrate
```
- After that, I brought the Conda environment up-to-date, because the new highcharts module was missing:
```
conda env update -f=environment.yml
```
- When I was starting the local dev server, I had an 500 with following error message:

> Truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all()

The reason was, because of an API change in highcharts. @henhuy fixed the concerning code on my machine. This is reflected in the commit of this pull request. Please feel free to review this commit and to merge it into the dev branch. I think, this may also fixes the problem you are describing in the internal email conversion with you and @henhuy named "Highcharts refactored" from Wed 2/13/2019 1:29 PM.

Thanks @henhuy, this was very helpful!
