### PR TITLE
Fix highcharts in results, render viz via new widget class

### DIFF
--- a/templates/stemp_abw/map.html
+++ b/templates/stemp_abw/map.html
@@ -91,12 +91,12 @@
                           </p>
                           <div class="grid-x">
                             <div class="cell" id="scenarios-wrap">
-                              <ul class="tabs" data-deep-link="true" data-update-history="true" data-deep-link-smudge="true" data-deep-link-smudge-delay="500" data-tabs id="deeplinked-tabs">
+                              <ul class="tabs" data-deep-link="true" data-update-history="true" data-deep-link-smudge="true" data-deep-link-smudge-delay="500" data-tabs id="deeplinked-tabs-1">
                                 <li class="tabs-title tabs-title--horizontal is-active"><a href="#scenario-panel1" aria-selected="true">Szenarien</a></li>
                                 <li class="tabs-title tabs-title--horizontal"><a href="#scenario-panel2">User-Szenarien</a></li>
                               </ul>
 
-                              <div class="tabs-content" data-tabs-content="deeplinked-tabs">
+                              <div class="tabs-content" data-tabs-content="deeplinked-tabs-1">
                                 <div class="tabs-panel is-active" id="scenario-panel1">
                                   <div class="grid-x grid-margin-x">
                                     <div class="cell">
@@ -206,7 +206,7 @@
                             <div class="cell" id="results-collapsed">
                               <p>Some results</p>
                             </div>
-                            {% include "stemp_abw/results_full.html" %}
+                            {{ results_widget }}
                           </div>
                         </div>
 
@@ -219,12 +219,12 @@
 
                         <div class="grid-x">
                           <div class="cell" id="areas-wrap">
-                            <ul class="tabs" data-deep-link="true" data-update-history="true" data-deep-link-smudge="true" data-deep-link-smudge-delay="500" data-tabs id="deeplinked-tabs">
+                            <ul class="tabs" data-deep-link="true" data-update-history="true" data-deep-link-smudge="true" data-deep-link-smudge-delay="500" data-tabs id="deeplinked-tabs-2">
                               <li class="tabs-title tabs-title--horizontal is-active"><a href="#areas-panel1" aria-selected="true">Variierbare Flächen</a></li>
                               <li class="tabs-title tabs-title--horizontal"><a href="#areas-panel2">Statische Flächen</a></li>
                             </ul>
 
-                            <div class="tabs-content" data-tabs-content="deeplinked-tabs">
+                            <div class="tabs-content" data-tabs-content="deeplinked-tabs-2">
 
                               <div class="tabs-panel is-active" id="areas-panel1">
                                 <div class="grid-x">
@@ -423,6 +423,9 @@
 {% endblock %}
 
 {% block scripts %}
+    <script>
+        {{ results_widget.media }}
+    </script>
     <!-- LOAD SLIDER DATA -->
     <script type="text/javascript">
         // slider markers

--- a/templates/stemp_abw/results.html
+++ b/templates/stemp_abw/results.html
@@ -1,12 +1,5 @@
-
-  <!--<div class="cell l-bg-color-w scen-create__wrapper u-text&#45;&#45;center">-->
-    <!--<div class="grid-x grid-padding-x">-->
-    {% for visualization in visualizations1 %}
-        <div class="cell small-4">
-          {{visualization.div|safe}}
-          {{visualization.script|safe}}
-        </div>
-    {% endfor %}
-
-    <!--</div>-->
-  <!--</div>-->
+{% for visualization in visualizations1 %}
+  <div class="cell small-4">
+    {{ visualization|safe }}
+  </div>
+{% endfor %}

--- a/templates/stemp_abw/results2.html
+++ b/templates/stemp_abw/results2.html
@@ -1,12 +1,5 @@
-
-  <!--<div class="cell l-bg-color-w scen-create__wrapper u-text&#45;&#45;center">-->
-    <!--<div class="grid-x grid-padding-x">-->
-    {% for visualization in visualizations2 %}
-        <div class="cell small-4">
-          {{visualization.div|safe}}
-          {{visualization.script|safe}}
-        </div>
-    {% endfor %}
-
-    <!--</div>-->
-  <!--</div>-->
+{% for visualization in visualizations2 %}
+  <div class="cell small-4">
+    {{visualization|safe}}
+  </div>
+{% endfor %}

--- a/templates/stemp_abw/results_full.html
+++ b/templates/stemp_abw/results_full.html
@@ -1,5 +1,5 @@
               <div class="cell" id="results-wrap" class="results-display-none">
-                <ul class="tabs" data-deep-link="true" data-update-history="true" data-deep-link-smudge="true" data-deep-link-smudge-delay="500" data-tabs id="deeplinked-tabs">
+                <ul class="tabs" data-deep-link="true" data-update-history="true" data-deep-link-smudge="true" data-deep-link-smudge-delay="500" data-tabs id="deeplinked-tabs-3">
                   <li class="tabs-title tabs-title--horizontal is-active"><a href="#results-panel1" aria-selected="true">Erneuerbare Energien</a></li>
                   <li class="tabs-title tabs-title--horizontal"><a href="#results-panel2">Konventionelle Kraftwerke</a></li>
                   <li class="tabs-title tabs-title--horizontal"><a href="#results-panel3">Wärmebedarf</a></li>
@@ -11,7 +11,7 @@
                   <!--<li class="tabs-title"><a href="#results-panel9">Batterie</a></li>-->
                 </ul>
 
-                <div class="tabs-content" data-tabs-content="deeplinked-tabs">
+                <div class="tabs-content" data-tabs-content="deeplinked-tabs-3">
                   <div class="tabs-panel is-active" id="results-panel1">
                     <div class="grid-x grid-margin-x">
                       <div class="cell small-4">
@@ -73,7 +73,6 @@
                           </tbody>
                         </table>
                       </div>
-
                       {% include "stemp_abw/results.html" %}
                     </div>
                   </div>
@@ -84,7 +83,7 @@
                   </div>
                   <div class="tabs-panel" id="results-panel3">
                     <div class="grid-x grid-margin-x">
-                      <div class="cell small-4                                  ">Insert results here</div>
+                      <div class="cell small-4">Insert results here</div>
                       <div class="cell small-4">Insert results here</div>
                       <div class="cell small-4">Insert results here</div>
                     </div>

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 from stemp_abw.config import io
 from stemp_abw.simulation.bookkeeping import simulate_energysystem
 from stemp_abw import results
+from stemp_abw.widgets import ResultsWidget
 
 from stemp_abw.views.detail_views import *
 from stemp_abw.views.serial_views import *
@@ -59,8 +60,9 @@ class MapView(TemplateView):
                   }
         visualizations2 = [results.ResultAnalysisVisualization(title=t, captions=c).visualize()
                           for t, c in labels2.items()]
-        context['visualizations1'] = visualizations1
-        context['visualizations2'] = visualizations2
+
+        # Put visualizations1 and visualizations2 in results_widget
+        context['results_widget'] = ResultsWidget(visualizations1, visualizations2)
 
         # Trial: new info button
         # TODO: Move

--- a/widgets.py
+++ b/widgets.py
@@ -1,4 +1,7 @@
 from django.forms.widgets import CheckboxInput, NumberInput
+from django.utils.safestring import mark_safe
+
+from utils.widgets import CustomWidget
 
 
 class LayerSelectWidget(CheckboxInput):
@@ -30,5 +33,33 @@ class SliderWidget(NumberInput):
     #     #context['widget']['precision'] = self.__get_precision()
     #     return context
 
+
 class SwitchWidget(NumberInput):
     template_name = 'widgets/switch.html'
+
+
+class ResultsWidget(CustomWidget):
+    template_name = 'stemp_abw/results_full.html'
+
+    def __init__(self, visualizations1, visualizations2):
+        self.visualizations1 = visualizations1
+        self.visualizations2 = visualizations2
+
+    def get_context(self):
+        return {
+            'visualizations1': self.visualizations1,
+            'visualizations2': self.visualizations2
+        }
+
+    def media(self):
+        # Join all vis arrays
+        vis_all = self.visualizations1 + self.visualizations2
+        html = (
+            "$('#btnExpand').on('click', function(e) {"
+                "if ($('#panel-results').hasClass('is-collapsed')) {"
+                    "setTimeout(function(){" +
+                    '\n'.join([vis.media() for vis in vis_all]) +
+                    "; }, 750);"
+            "}});"
+        )
+        return mark_safe(html)


### PR DESCRIPTION
Hi @nesnoj,

@henhuy and I worked today on a fix for the highcharts loading issue in the results #9 and came up with a working solution :tada:

The Good:

- We came up with a dedicated widget class, which makes implementing the {{ vis.media }} tags in the script block possible, which is needed, because they have to be loaded after app.js (before that, in this case, this was not possible, because we had nested results templates). 

The Bad:

- This pull request doesn't solve the highcharts loading issue in the layer popups. Which is on my task list next.

The Ugly:

- We had big issues loading the {{ vis.media }} tags at the right moment in time, because there is a animation involved, which is seems to be triggered deep in the CSS code. Finally we settled for an not super nice but (for now) working solution, in which we set an timeout of 750 ms. I think, if @bmlancien is back, we can look for a better way, but for now and considering the time we have left, I think this solution is viable.

PS: This pull request depends on an other minor change in the WAM base project for which I also created a pull request https://github.com/rl-institut/WAM/pull/15