### PR TITLE
fix highcharts in results without widget

### DIFF
--- a/results.py
+++ b/results.py
@@ -25,7 +25,11 @@ class ResultAnalysisVisualization(object):
     def visualize(self):
         visualization = visualizations.HCTimeseries(
             data=self.data,
-            title=self.title,
-            style='display: inline-block'
+            title=self.title
+            # Note: inline-block originally used to make sure the graph is
+            # scaled correctly even if the expansion of the result panel has
+            # not finished before the HC graphs are loaded. Deactivated since
+            # the graphs do not scale properly if window is resized.
+            #style='display: inline-block'
         )
         return visualization

--- a/templates/stemp_abw/map.html
+++ b/templates/stemp_abw/map.html
@@ -434,7 +434,7 @@
             {% for visualization in visualizations2 %}
                   {{visualization.media}}
             {% endfor %}
-      }, 750);
+          }, 750);
       }});
     </script>
 

--- a/templates/stemp_abw/map.html
+++ b/templates/stemp_abw/map.html
@@ -423,6 +423,21 @@
 {% endblock %}
 
 {% block scripts %}
+    <!-- LOAD HIGHCHART DATA -->
+    <script>
+      $('#btnExpand').on('click', function(e) {
+        if ($('#panel-results').hasClass('is-collapsed')) {
+          setTimeout(function() {
+            {% for visualization in visualizations1 %}
+                  {{visualization.media}}
+            {% endfor %}
+            {% for visualization in visualizations2 %}
+                  {{visualization.media}}
+            {% endfor %}
+      }, 750);
+      }});
+    </script>
+
     <!-- LOAD SLIDER DATA -->
     <script type="text/javascript">
         // slider markers

--- a/templates/stemp_abw/results.html
+++ b/templates/stemp_abw/results.html
@@ -3,8 +3,7 @@
     <!--<div class="grid-x grid-padding-x">-->
     {% for visualization in visualizations1 %}
         <div class="cell small-4">
-          {{visualization.div|safe}}
-          {{visualization.script|safe}}
+          {{visualization|safe}}
         </div>
     {% endfor %}
 

--- a/templates/stemp_abw/results2.html
+++ b/templates/stemp_abw/results2.html
@@ -3,8 +3,7 @@
     <!--<div class="grid-x grid-padding-x">-->
     {% for visualization in visualizations2 %}
         <div class="cell small-4">
-          {{visualization.div|safe}}
-          {{visualization.script|safe}}
+          {{visualization|safe}}
         </div>
     {% endfor %}
 

--- a/templates/stemp_abw/results_full.html
+++ b/templates/stemp_abw/results_full.html
@@ -84,7 +84,7 @@
                   </div>
                   <div class="tabs-panel" id="results-panel3">
                     <div class="grid-x grid-margin-x">
-                      <div class="cell small-4                                  ">Insert results here</div>
+                      <div class="cell small-4">Insert results here</div>
                       <div class="cell small-4">Insert results here</div>
                       <div class="cell small-4">Insert results here</div>
                     </div>

--- a/visualizations.py
+++ b/visualizations.py
@@ -16,8 +16,10 @@ class HCTimeseries(HCStemp):
     setup = {
         'chart': {
             'type': 'line',
-            'backgroundColor': '#EBF2FA',
-            'height': str(int(9 / 16 * 100)) + '%' # 16:9 ratio
+            'backgroundColor': '#EBF2FA'
+            # TODO: height attribute not set since it cuts off the graph at its
+            # bottom, needs to be revised if needed
+            #'height': str(int(9 / 16 * 100)) + '%',  # 16:9 ratio
         },
         'title': {
             'text': '',


### PR DESCRIPTION
As announced in #16, this is an alternative fix for the result HCs. I'd prefer not to introduce a new widget for the entire result page. Instead, a single chart could make its way into a widget, but we can discuss this next week.
This fix keeps the current subtemplate structure, changes the template tags according to @henhuy's refactoring and moves the script part to the bottom (below foundation's js).

**Concerning the broken graphs:**
Last October, I had similar issues with the loading of HC results as the HC charts were loaded before result panel expansion was completed.

I see 2 solutions for this:
1. Pass [`display: inline-block`](https://github.com/rl-institut/WAM_APP_stemp_abw/blob/fix/highcharts-in-results-without-widget/results.py#L33) style to the HC div, this is the solution as recommended by @bmlancien last year which I'be been using since. The problem here is that the graphs do not scale properly when window is resized (as block elements, they keep their size of course).
2. Use the `setTimeout()` you introduced in #16. Although it's not the most beautiful way, I prefer this solution. Thank you :+1: ! I just wrapped it around the [HC script loading](https://github.com/rl-institut/WAM_APP_stemp_abw/blob/fix/highcharts-in-results-without-widget/templates/stemp_abw/map.html#L430-L437).

This fix works with the current master of wam (https://github.com/rl-institut/WAM/pull/15 merged)

By the way: The duration of panel expansion is set in [app.js](https://github.com/rl-institut/WAM_APP_stemp_abw/blob/f5a8a59411a704b5366a23ac04f9525ff5d4a276/static/stemp_abw/foundation/js/app.js) L42319 & L42322 (cannot provide a link to the lines here as the file is not displayed by github).

What do you think, can you live with this solution?