### PR TITLE
Allow only one choropleth map at once

### DIFF
--- a/templates/stemp_abw/map.html
+++ b/templates/stemp_abw/map.html
@@ -783,7 +783,12 @@
                 id = id.replace('cb_region_', '');
                 for (var l in legends) {
                   if (l !== id && choropleth_data.hasOwnProperty(id)) {
-                    if (this.checked) map.removeControl(legends[l]);
+                    if (this.checked) {
+                        map.removeLayer(layers[l]);
+                        map.removeControl(legends[l]);
+                        var el = document.getElementById('cb_region_' + l);
+                        el.checked = false;
+                    }
                   } else if (l === id) {
                     l = legends[id];
                     if (this.checked) l.addTo(map);


### PR DESCRIPTION
Hi @nesnoj,

this pull request fixes issue #14 by only allowing one choropleth map at once as agreed on in #14 as well. Please review the code and feel free to merge it.